### PR TITLE
IST-3261: Natural sorting by number code stopped working

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1061,7 +1061,7 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
       return callback(err);
     }
 
-    var collation = options && options.collation;
+    var collation = options?.collation ?? filter?.collation;
     if (collation) {
       cursor.collation(collation);
     }

--- a/package.json
+++ b/package.json
@@ -119,5 +119,5 @@
     "posttest": "npm run lint",
     "test": "mocha -G --timeout 10000 --require test/init.js test/*.test.js"
   },
-  "version": "3.2.0"
+  "version": "3.2.1"
 }


### PR DESCRIPTION
Relates to: https://sysdyne.atlassian.net/browse/IST-3261

This PR introduces ability to set MongoDB collation with query filter, previously present but currently not working. This allows for natural number sorting in `find`-related queries in iStrada.