### PR TITLE
fix: fixed modification of data for database being given after save

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -424,9 +424,9 @@ MongoDB.prototype.save = function(model, data, options, callback) {
   data._id = oid;
   idName !== '_id' && delete data[idName];
 
-  data = self.toDatabase(model, data);
+  const dbData = self.toDatabase(model, data);
 
-  this.execute(model, 'save', data, {}, function(err, result) {
+  this.execute(model, 'save', dbData, {}, function(err, result) {
     if (!err) {
       self.setIdValue(model, data, idValue);
       idName !== '_id' && delete data._id;


### PR DESCRIPTION
Related to: https://sysdyne.atlassian.net/browse/IST-3359

This attempts to fix differences in MQTT and normal responses, which is caused by data being modified before being sent to database, but returning the same format, with fields changed, to the Loopback API. This means that if `column` field is used in model definition, that name would be used in hooks after `.save()` is triggered. This changes that behaviour, fixing it for all such cases. I think this is more natural than the current behaviour.