### PR TITLE
feat: added export of mongo ObjectID used by the connector

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -13,6 +13,8 @@ var async = require('async');
 var Connector = require('loopback-connector').Connector;
 var debug = require('debug')('loopback:connector:mongodb');
 
+exports.MongoObjectID = mongodb.ObjectID;
+
 exports.ObjectID = ObjectID;
 /*!
  * Convert the id to be a BSON ObjectID if it is compatible


### PR DESCRIPTION
Needed for: https://sysdyne.atlassian.net/browse/IST-3393

This exports MongoDB's `ObjectID` used by this connector so `instanceof` can be used in iStrada API to check if something is an ObjectID coming from the connector.