### PR TITLE
fix: add hasOwnProperty check do property-column mapping

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1007,12 +1007,12 @@ MongoDB.prototype.convertColumnNames = function(model, data, direction) {
       continue;
     }
 
-    if (direction === 'database') {
+    if (direction === 'database' && data.hasOwnProperty(propName)) {
       data[columnName] = data[propName];
       delete data[propName];
     }
 
-    if (direction === 'property') {
+    if (direction === 'property' && data.hasOwnProperty(columnName)) {
       data[propName] = data[columnName];
       delete data[columnName];
     }


### PR DESCRIPTION
Fix for this problem from upstream: https://github.com/loopbackio/loopback-connector-mongodb/issues/574

Makes not existing properties in data on partial updates not being written as `null`.